### PR TITLE
Default JobDef Path Fix

### DIFF
--- a/flowmancer/flowmancer.py
+++ b/flowmancer/flowmancer.py
@@ -160,6 +160,10 @@ class Flowmancer:
         default_jobdef_path: Optional[str] = None,
         default_jobdef_type: str = 'yaml'
     ) -> None:
+        # If a relative path is given in `start()`, it should be relative to the `start()` call. This is in contrast
+        # to path given from command line, in which that case paths should be relative to where the command is executed.
+        if default_jobdef_path and not default_jobdef_path.startswith('/'):
+            default_jobdef_path = os.path.join(app_root_dir, default_jobdef_path)
         parser = ArgumentParser(description='Flowmancer job execution options.')
         parser.add_argument('-j', '--jobdef', action='store', dest='jobdef', default=default_jobdef_path)
         parser.add_argument('-t', '--type', action='store', dest='jobdef_type', default=default_jobdef_type)


### PR DESCRIPTION
Changed behavior of default jobdef path arg for start to be with respect to the location of the python code, not CWD