### PR TITLE
0.12

### DIFF
--- a/flowmancer/flowmancer.py
+++ b/flowmancer/flowmancer.py
@@ -504,7 +504,7 @@ class Flowmancer:
         for n, t in jobdef.tasks.items():
             self.add_executor(
                 name=n,
-                task_class=t.task,
+                task_class=t.variant,
                 deps=t.dependencies,
                 max_attempts=t.max_attempts,
                 backoff=t.backoff,
@@ -512,17 +512,17 @@ class Flowmancer:
             )
 
         # Checkpointer
-        self._checkpointer_instance = _checkpointer_classes[jobdef.checkpointer.checkpointer](
+        self._checkpointer_instance = _checkpointer_classes[jobdef.checkpointer.variant](
             **jobdef.checkpointer.parameters
         )
 
         # Observers
         for n, e in jobdef.extensions.items():
-            self._registered_extensions[n] = _extension_classes[e.extension](**e.parameters)
+            self._registered_extensions[n] = _extension_classes[e.variant](**e.parameters)
 
         # Loggers
         for n, l in jobdef.loggers.items():
-            self._registered_loggers[n] = _logger_classes[l.logger](**l.parameters)
+            self._registered_loggers[n] = _logger_classes[l.variant](**l.parameters)
 
         return self
 

--- a/flowmancer/flowmancer.py
+++ b/flowmancer/flowmancer.py
@@ -505,7 +505,7 @@ class Flowmancer:
             self.add_executor(
                 name=n,
                 task_class=t.variant,
-                deps=t.dependencies,
+                deps=t.depends_on,
                 max_attempts=t.max_attempts,
                 backoff=t.backoff,
                 parameters=t.parameters

--- a/flowmancer/jobdefinition/__init__.py
+++ b/flowmancer/jobdefinition/__init__.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 _job_definition_classes = dict()
 
@@ -19,16 +19,16 @@ def job_definition(key: str) -> Callable:
 
 
 class JobDefinitionComponent(BaseModel):
-    model_config = ConfigDict(extra='forbid', use_enum_values=True)
+    model_config = ConfigDict(extra='forbid', use_enum_values=True, populate_by_name=True)
 
 
 class LoggerDefinition(JobDefinitionComponent):
-    logger: str
+    variant: str = Field(alias='logger')
     parameters: Dict[str, Any] = dict()
 
 
 class TaskDefinition(JobDefinitionComponent):
-    task: str
+    variant: str = Field(alias='task')
     dependencies: List[str] = []
     max_attempts: int = 1
     backoff: int = 0
@@ -36,7 +36,7 @@ class TaskDefinition(JobDefinitionComponent):
 
 
 class ExtensionDefinition(JobDefinitionComponent):
-    extension: str
+    variant: str = Field(alias='extension')
     parameters: Dict[str, Any] = dict()
 
 
@@ -52,7 +52,7 @@ class ConfigurationDefinition(JobDefinitionComponent):
 
 
 class CheckpointerDefinition(JobDefinitionComponent):
-    checkpointer: str
+    variant: str = Field(alias='checkpointer')
     parameters: Dict[str, Any] = dict()
 
 
@@ -61,9 +61,11 @@ class JobDefinition(JobDefinitionComponent):
     include: List[Path] = []
     config: ConfigurationDefinition = ConfigurationDefinition()
     tasks: Dict[str, TaskDefinition]
-    loggers: Dict[str, LoggerDefinition] = {'file-logger': LoggerDefinition(logger='FileLogger')}
-    extensions: Dict[str, ExtensionDefinition] = {'progress-bar': ExtensionDefinition(extension='RichProgressBar')}
-    checkpointer: CheckpointerDefinition = CheckpointerDefinition(checkpointer='FileCheckpointer')
+    loggers: Dict[str, LoggerDefinition] = {'file-logger': LoggerDefinition(variant='FileLogger')}  # type: ignore
+    extensions: Dict[str, ExtensionDefinition] = {
+        'progress-bar': ExtensionDefinition(variant='RichProgressBar')  # type: ignore
+    }
+    checkpointer: CheckpointerDefinition = CheckpointerDefinition(variant='FileCheckpointer')  # type: ignore
 
 
 class LoadParams(BaseModel):

--- a/flowmancer/jobdefinition/__init__.py
+++ b/flowmancer/jobdefinition/__init__.py
@@ -29,7 +29,7 @@ class LoggerDefinition(JobDefinitionComponent):
 
 class TaskDefinition(JobDefinitionComponent):
     variant: str = Field(alias='task')
-    dependencies: List[str] = []
+    depends_on: List[str] = Field(alias='dependencies', default_factory=list)
     max_attempts: int = 1
     backoff: int = 0
     parameters: Dict[str, Any] = dict()

--- a/tests/jobdefinition/test_file.py
+++ b/tests/jobdefinition/test_file.py
@@ -47,7 +47,7 @@ def test_env_var_defaults(
     })
     j = load_yaml_jobdef('a.yaml')
     assert(j.config.name == 'default name')
-    assert(j.tasks['test'].task == 'Test')
+    assert(j.tasks['test'].variant == 'Test')
 
 
 def test_env_var_with_inputs(
@@ -67,8 +67,8 @@ def test_env_var_with_inputs(
     del os.environ['JOB_NAME']
     del os.environ['TASK_CLASS']
     assert(j.config.name == 'custom step name')
-    assert(j.tasks['test'].task == 'DoSomething')
-    assert(j.tasks['notreal'].task == '')
+    assert(j.tasks['test'].variant == 'DoSomething')
+    assert(j.tasks['notreal'].variant == '')
 
 
 def test_sys_var(
@@ -103,8 +103,8 @@ def test_var_as_literal(
         }
     }, True)
     j = load_yaml_jobdef('a.yaml')
-    assert(j.tasks['escaped_env'].task == '$ENV{LITERAL}')
-    assert(j.tasks['escaped_sys'].task == '$SYS{LITERAL}')
+    assert(j.tasks['escaped_env'].variant == '$ENV{LITERAL}')
+    assert(j.tasks['escaped_sys'].variant == '$SYS{LITERAL}')
 
 
 def test_include_order(
@@ -145,7 +145,7 @@ def test_include_order(
     write_yaml('c.yaml', c)
     jdef = load_yaml_jobdef('c.yaml')
     assert(jdef.config.name == 'c')
-    assert(jdef.tasks['do-something'].task == 'DoSomethingElse')
+    assert(jdef.tasks['do-something'].variant == 'DoSomethingElse')
 
 
 def test_nested_include(
@@ -188,19 +188,19 @@ def test_nested_include(
     write_yaml('c.yaml', c)
     jdef = load_yaml_jobdef('c.yaml')
     assert(jdef.config.name == 'c')
-    assert(jdef.tasks['do-something'].task == 'DoSomethingElse')
+    assert(jdef.tasks['do-something'].variant == 'DoSomethingElse')
 
 
 def test_relative_path_include(
     write_yaml: Callable[[str, Dict[str, Any]], Path],
     load_yaml_jobdef: Callable[[str], JobDefinition]
 ) -> None:
-    a = {'tasks': {'do-something': {'task': 'DoSomething'}}}
-    b = {'include': ['./a.yaml'], 'tasks': {'do-something': {'task': 'DoSomethingElse'}}}
+    a = {'tasks': {'do-something': {'variant': 'DoSomething'}}}
+    b = {'include': ['./a.yaml'], 'tasks': {'do-something': {'variant': 'DoSomethingElse'}}}
     write_yaml('a.yaml', a)
     write_yaml('b.yaml', b)
     jdef = load_yaml_jobdef('b.yaml')
-    assert(jdef.tasks['do-something'].task == 'DoSomethingElse')
+    assert(jdef.tasks['do-something'].variant == 'DoSomethingElse')
 
 
 def test_aliases(
@@ -221,7 +221,7 @@ def test_aliases(
         '      msg: *a\n'
         '      numbers: *b\n'
         '  do-another-thing:\n'
-        '    task: DoSomething\n'
+        '    variant: DoSomething\n'
         '    parameters:\n'
         '      <<: *c\n'
         '      numbers: [999, 9999, 99999]\n'


### PR DESCRIPTION
* Standardize class names specified in `task`, `checkpointer`, `extension`, `logger`, etc. with consistent `variant` field name. Old field names converted to aliases and will still be usable in configurations for a brief time.
* Swap `dependencies` in task entries with `depends_on`. Original field name converted to alias and will still be usable for a brief of time.